### PR TITLE
Add verifier tests to Unity tests

### DIFF
--- a/test/unity/CMakeLists.txt
+++ b/test/unity/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(unit_tests_app unit_tests.c test_helpers.c serialization_tests.c varint_tests.c)
+add_executable(unit_tests_app unit_tests.c test_helpers.c serialization_tests.c varint_tests.c verifier_tests.c)
 target_link_libraries(unit_tests_app unity macaroons)
 
 add_test(unit_tests unit_tests_app)

--- a/test/unity/test_helpers.c
+++ b/test/unity/test_helpers.c
@@ -5,6 +5,7 @@
 /* C */
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 
 /* macaroons */
 #include <libmacaroons/macaroons.h>
@@ -22,15 +23,75 @@ struct parsed_macaroon {
     enum macaroon_format F;
 };
 
-struct macaroon *deserialize_macaroon(const char *serialized) {
-    size_t buf_sz = strlen(serialized + 1);
-    unsigned char *buf = malloc(buf_sz);
+struct verifier_test {
+    int version;
+    bool authorized;
+    char *serialized;
+    unsigned char *key;
+    size_t num_caveats;
+    char **caveats;
+};
 
-    memset(buf, 0, sizeof(*buf));
+struct macaroon *deserialize_macaroon(const char *serialized) {
+    size_t buf_sz = strlen(serialized);
+    unsigned char *buf = malloc(buf_sz);
+    TEST_ASSERT_NOT_NULL_MESSAGE(buf, "Buffer cannot be null");
+
+//    memset(buf, 0, sizeof(*buf));
     int rc = b64_pton(serialized, buf, buf_sz);
 
-    enum macaroon_returncode err;
+    enum macaroon_returncode err = MACAROON_SUCCESS;
     struct macaroon *M = macaroon_deserialize(buf, int2size_t(rc), &err);
+    free(buf);
     TEST_ASSERT_EQUAL_INT_MESSAGE(MACAROON_SUCCESS, err, "Should have successfully deserialized");
     return M;
+}
+
+
+void verify_macaroon(const struct verifier_test *test) {
+
+    struct macaroon_verifier *V = NULL;
+    struct macaroon **macaroons = NULL;
+    size_t macaroons_sz = 0;
+
+    V = macaroon_verifier_create();
+    TEST_ASSERT_NOT_NULL_MESSAGE(V, "Verifier should create ok");
+
+    // Add all the caveats
+    for(size_t i = 0; i < test->num_caveats; i++) {
+        char* caveat = test->caveats[i];
+        enum macaroon_returncode err = MACAROON_SUCCESS;
+        macaroon_verifier_satisfy_exact(V, (const unsigned char*)caveat, strlen(caveat), &err);
+        TEST_ASSERT_EQUAL_INT_MESSAGE(MACAROON_SUCCESS, err, "Should have added caveat");
+    }
+
+    // Deserialize the macaroon
+
+    struct macaroon *M = deserialize_macaroon(test->serialized);
+
+    TEST_ASSERT_NOT_NULL_MESSAGE(M, "Macaroon should deserialize correctly");
+
+    struct macaroon **tmp;
+
+    ++macaroons_sz;
+    tmp = realloc(macaroons, macaroons_sz * sizeof(struct macaroon *));
+    TEST_ASSERT_NOT_NULL(tmp);
+
+    macaroons = tmp;
+    (macaroons)[macaroons_sz - 1] = M;
+
+    // Ok, now let's verify it
+    const size_t key_sz = strlen(test->key);
+    enum macaroon_returncode err;
+    int verify = macaroon_verify(V, macaroons[0], test->key, key_sz, macaroons + 1, macaroons_sz - 1, &err);
+
+    if (verify != 0 && err != MACAROON_NOT_AUTHORIZED) {
+        char *str = "";
+        sprintf(str, "verification encountered exceptional error: %s\n", macaroon_error(err));
+        TEST_FAIL_MESSAGE(str);
+    } else if (verify == 0 && !test->authorized) {
+        TEST_FAIL_MESSAGE("verification passed for \"unauthorized\" scenario\n");
+    } else if (verify != 0 && err == MACAROON_NOT_AUTHORIZED && test->authorized) {
+        TEST_FAIL_MESSAGE("verification failed for \"authorized\" scenario\n");
+    }
 }

--- a/test/unity/test_helpers.c
+++ b/test/unity/test_helpers.c
@@ -81,7 +81,7 @@ void verify_macaroon(const struct verifier_test *test) {
     (macaroons)[macaroons_sz - 1] = M;
 
     // Ok, now let's verify it
-    const size_t key_sz = strlen(test->key);
+    const size_t key_sz = strlen((const char*)test->key);
     enum macaroon_returncode err;
     int verify = macaroon_verify(V, macaroons[0], test->key, key_sz, macaroons + 1, macaroons_sz - 1, &err);
 

--- a/test/unity/unit_tests.c
+++ b/test/unity/unit_tests.c
@@ -3,6 +3,7 @@
 static void RunAllTests(void) {
     RUN_TEST_GROUP(SerializationTests);
     RUN_TEST_GROUP(VarintTests);
+    RUN_TEST_GROUP(VerifierTests);
 }
 
 int main(int argc, const char * argv[]) {

--- a/test/unity/verifier_tests.c
+++ b/test/unity/verifier_tests.c
@@ -125,7 +125,7 @@ TEST(VerifierTests, caveat_v1_3) {
 
 TEST(VerifierTests, caveat_v1_4) {
     static const size_t num_caveats = 2;
-    const char *caveats[num_caveats] = {
+    const char *caveats[2] = {
             "account = 3735928559",
             "user = alice"
     };
@@ -148,7 +148,7 @@ TEST(VerifierTests, caveat_v1_4) {
 
 TEST(VerifierTests, caveat_v1_5) {
     static const size_t num_caveats = 1;
-    const char *caveats[num_caveats] = {
+    const char *caveats[1] = {
             "account = 3735928559",
     };
     const char **c = (const char**)(malloc(num_caveats * sizeof(char*)));
@@ -170,7 +170,7 @@ TEST(VerifierTests, caveat_v1_5) {
 
 TEST(VerifierTests, caveat_v1_6) {
     static const size_t num_caveats = 1;
-    const char *caveats[num_caveats] = {
+    const char *caveats[1] = {
             "user = alice",
     };
     const char **c = (const char**)(malloc(num_caveats * sizeof(char*)));
@@ -192,7 +192,7 @@ TEST(VerifierTests, caveat_v1_6) {
 
 TEST(VerifierTests, caveat_v2_1) {
     static const size_t num_caveats = 1;
-    const char *caveats[num_caveats] = {
+    const char *caveats[1] = {
             "account = 3735928559",
     };
     const char **c = (const char**)(malloc(num_caveats * sizeof(char*)));
@@ -214,7 +214,7 @@ TEST(VerifierTests, caveat_v2_1) {
 
 TEST(VerifierTests, caveat_v2_2) {
     static const size_t num_caveats = 1;
-    const char *caveats[num_caveats] = {
+    const char *caveats[1] = {
             "account = 0000000000",
     };
     const char **c = (const char**)(malloc(num_caveats * sizeof(char*)));
@@ -247,7 +247,7 @@ TEST(VerifierTests, caveat_v2_3) {
 
 TEST(VerifierTests, caveat_v2_4) {
     static const size_t num_caveats = 2;
-    const char *caveats[num_caveats] = {
+    const char *caveats[2] = {
             "account = 3735928559",
             "user = alice",
     };
@@ -270,7 +270,7 @@ TEST(VerifierTests, caveat_v2_4) {
 
 TEST(VerifierTests, caveat_v2_5) {
     static const size_t num_caveats = 1;
-    const char *caveats[num_caveats] = {
+    const char *caveats[1] = {
             "account = 3735928559",
     };
     const char **c = (const char**)(malloc(num_caveats * sizeof(char*)));
@@ -292,7 +292,7 @@ TEST(VerifierTests, caveat_v2_5) {
 
 TEST(VerifierTests, caveat_v2_6) {
     static const size_t num_caveats = 1;
-    const char *caveats[num_caveats] = {
+    const char *caveats[1] = {
             "user = alice",
     };
     const char **c = (const char**)(malloc(num_caveats * sizeof(char*)));

--- a/test/unity/verifier_tests.c
+++ b/test/unity/verifier_tests.c
@@ -10,10 +10,10 @@
 struct verifier_test {
     int version;
     bool authorized;
-    char *serialized;
-    unsigned char *key;
+    const char *serialized;
+    const char *key;
     size_t num_caveats;
-    char **caveats;
+    const char **caveats;
 };
 
 void verify_macaroon(const struct verifier_test* test);
@@ -70,9 +70,9 @@ TEST(VerifierTests, root_v2_2) {
 }
 
 TEST(VerifierTests, caveat_v1_1) {
-    char *caveats[1] = {"account = 3735928559"};
+    const char *caveats[1] = {"account = 3735928559"};
 
-    char **c = (char**)(malloc(1 * sizeof(char*)));
+    const char **c = (const char**)(malloc(1 * sizeof(char*)));
 
     c[0] = caveats[0];
 
@@ -88,9 +88,9 @@ TEST(VerifierTests, caveat_v1_1) {
 }
 
 TEST(VerifierTests, caveat_v1_2) {
-    char *caveats[1] = {"account = 0000000000"};
+    const char *caveats[1] = {"account = 0000000000"};
 
-    char **c = (char**)(malloc(1 * sizeof(char*)));
+    const char **c = (const char**)(malloc(1 * sizeof(char*)));
 
     c[0] = caveats[0];
 
@@ -105,6 +105,213 @@ TEST(VerifierTests, caveat_v1_2) {
     verify_macaroon(&t);
 }
 
+TEST(VerifierTests, caveat_v1_3) {
+    const char *caveats[1] = {"account = 0000000000"};
+
+    const char **c = (const char**)(malloc(1 * sizeof(char*)));
+
+    c[0] = caveats[0];
+
+    struct verifier_test t = {
+            .version = 1,
+            .authorized = false,
+            .key = "this is the key",
+            .serialized = "TURBeU1XeHZZMkYwYVc5dUlHaDBkSEE2THk5bGVHRnRjR3hsTG05eVp5OEtNREF4Tldsa1pXNTBhV1pwWlhJZ2EyVjVhV1FLTURBeFpHTnBaQ0JoWTJOdmRXNTBJRDBnTXpjek5Ua3lPRFUxT1Fvd01ESm1jMmxuYm1GMGRYSmxJUFZJQl9iY2J0LUl2dzl6QnJPQ0pXS2pZbE05djNNNXVtRjJYYVM5SloySENn",
+            .num_caveats = 0,
+            .caveats = c
+    };
+    verify_macaroon(&t);
+}
+
+TEST(VerifierTests, caveat_v1_4) {
+    const size_t num_caveats = 2;
+    const char *caveats[num_caveats] = {
+            "account = 3735928559",
+            "user = alice"
+    };
+    const char **c = (const char**)(malloc(num_caveats * sizeof(char*)));
+
+    for (size_t i = 0; i < num_caveats; i++) {
+        c[i] = caveats[i];
+    }
+
+    struct verifier_test t = {
+            .version = 1,
+            .authorized = true,
+            .key = "this is the key",
+            .serialized = "TURBeU1XeHZZMkYwYVc5dUlHaDBkSEE2THk5bGVHRnRjR3hsTG05eVp5OEtNREF4Tldsa1pXNTBhV1pwWlhJZ2EyVjVhV1FLTURBeFpHTnBaQ0JoWTJOdmRXNTBJRDBnTXpjek5Ua3lPRFUxT1Fvd01ESm1jMmxuYm1GMGRYSmxJUFZJQl9iY2J0LUl2dzl6QnJPQ0pXS2pZbE05djNNNXVtRjJYYVM5SloySENn",
+            .num_caveats = num_caveats,
+            .caveats = c
+    };
+    verify_macaroon(&t);
+}
+
+TEST(VerifierTests, caveat_v1_5) {
+    const size_t num_caveats = 1;
+    const char *caveats[num_caveats] = {
+            "account = 3735928559",
+    };
+    const char **c = (const char**)(malloc(num_caveats * sizeof(char*)));
+
+    for (size_t i = 0; i < num_caveats; i++) {
+        c[i] = caveats[i];
+    }
+
+    struct verifier_test t = {
+            .version = 1,
+            .authorized = false,
+            .key = "this is the key",
+            .serialized = "TURBeU1XeHZZMkYwYVc5dUlHaDBkSEE2THk5bGVHRnRjR3hsTG05eVp5OEtNREF4Tldsa1pXNTBhV1pwWlhJZ2EyVjVhV1FLTURBeFpHTnBaQ0JoWTJOdmRXNTBJRDBnTXpjek5Ua3lPRFUxT1Fvd01ERTFZMmxrSUhWelpYSWdQU0JoYkdsalpRb3dNREptYzJsbmJtRjBkWEpsSUV2cFo4MGVvTWF5YTY5cVNwVHVtd1d4V0liYUM2aGVqRUtwUEkwT0VsNzhDZw",
+            .num_caveats = num_caveats,
+            .caveats = c
+    };
+    verify_macaroon(&t);
+}
+
+TEST(VerifierTests, caveat_v1_6) {
+    const size_t num_caveats = 1;
+    const char *caveats[num_caveats] = {
+            "user = alice",
+    };
+    const char **c = (const char**)(malloc(num_caveats * sizeof(char*)));
+
+    for (size_t i = 0; i < num_caveats; i++) {
+        c[i] = caveats[i];
+    }
+
+    struct verifier_test t = {
+            .version = 1,
+            .authorized = false,
+            .key = "this is the key",
+            .serialized = "TURBeU1XeHZZMkYwYVc5dUlHaDBkSEE2THk5bGVHRnRjR3hsTG05eVp5OEtNREF4Tldsa1pXNTBhV1pwWlhJZ2EyVjVhV1FLTURBeFpHTnBaQ0JoWTJOdmRXNTBJRDBnTXpjek5Ua3lPRFUxT1Fvd01ERTFZMmxrSUhWelpYSWdQU0JoYkdsalpRb3dNREptYzJsbmJtRjBkWEpsSUV2cFo4MGVvTWF5YTY5cVNwVHVtd1d4V0liYUM2aGVqRUtwUEkwT0VsNzhDZw==",
+            .num_caveats = num_caveats,
+            .caveats = c
+    };
+    verify_macaroon(&t);
+}
+
+TEST(VerifierTests, caveat_v2_1) {
+    const size_t num_caveats = 1;
+    const char *caveats[num_caveats] = {
+            "account = 3735928559",
+    };
+    const char **c = (const char**)(malloc(num_caveats * sizeof(char*)));
+
+    for (size_t i = 0; i < num_caveats; i++) {
+        c[i] = caveats[i];
+    }
+
+    struct verifier_test t = {
+            .version = 1,
+            .authorized = true,
+            .key = "this is the key",
+            .serialized = "AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQAABiD1SAf23G7fiL8PcwazgiVio2JTPb9zObphdl2kvSWdhw",
+            .num_caveats = num_caveats,
+            .caveats = c
+    };
+    verify_macaroon(&t);
+}
+
+TEST(VerifierTests, caveat_v2_2) {
+    const size_t num_caveats = 1;
+    const char *caveats[num_caveats] = {
+            "account = 0000000000",
+    };
+    const char **c = (const char**)(malloc(num_caveats * sizeof(char*)));
+
+    for (size_t i = 0; i < num_caveats; i++) {
+        c[i] = caveats[i];
+    }
+
+    struct verifier_test t = {
+            .version = 1,
+            .authorized = false,
+            .key = "this is the key",
+            .serialized = "AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQAABiD1SAf23G7fiL8PcwazgiVio2JTPb9zObphdl2kvSWdhw",
+            .num_caveats = num_caveats,
+            .caveats = c
+    };
+    verify_macaroon(&t);
+}
+
+TEST(VerifierTests, caveat_v2_3) {
+
+    struct verifier_test t = {
+            .version = 1,
+            .authorized = false,
+            .key = "this is the key",
+            .serialized = "AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQAABiD1SAf23G7fiL8PcwazgiVio2JTPb9zObphdl2kvSWdhw",
+    };
+    verify_macaroon(&t);
+}
+
+TEST(VerifierTests, caveat_v2_4) {
+    const size_t num_caveats = 2;
+    const char *caveats[num_caveats] = {
+            "account = 3735928559",
+            "user = alice",
+    };
+    const char **c = (const char**)(malloc(num_caveats * sizeof(char*)));
+
+    for (size_t i = 0; i < num_caveats; i++) {
+        c[i] = caveats[i];
+    }
+
+    struct verifier_test t = {
+            .version = 1,
+            .authorized = true,
+            .key = "this is the key",
+            .serialized = "AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQACDHVzZXIgPSBhbGljZQAABiBL6WfNHqDGsmuvakqU7psFsViG2guoXoxCqTyNDhJe_A",
+            .num_caveats = num_caveats,
+            .caveats = c
+    };
+    verify_macaroon(&t);
+}
+
+TEST(VerifierTests, caveat_v2_5) {
+    const size_t num_caveats = 1;
+    const char *caveats[num_caveats] = {
+            "account = 3735928559",
+    };
+    const char **c = (const char**)(malloc(num_caveats * sizeof(char*)));
+
+    for (size_t i = 0; i < num_caveats; i++) {
+        c[i] = caveats[i];
+    }
+
+    struct verifier_test t = {
+            .version = 1,
+            .authorized = false,
+            .key = "this is the key",
+            .serialized = "AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQACDHVzZXIgPSBhbGljZQAABiBL6WfNHqDGsmuvakqU7psFsViG2guoXoxCqTyNDhJe_A",
+            .num_caveats = num_caveats,
+            .caveats = c
+    };
+    verify_macaroon(&t);
+}
+
+TEST(VerifierTests, caveat_v2_6) {
+    const size_t num_caveats = 1;
+    const char *caveats[num_caveats] = {
+            "user = alice",
+    };
+    const char **c = (const char**)(malloc(num_caveats * sizeof(char*)));
+
+    for (size_t i = 0; i < num_caveats; i++) {
+        c[i] = caveats[i];
+    }
+
+    struct verifier_test t = {
+            .version = 1,
+            .authorized = false,
+            .key = "this is the key",
+            .serialized = "AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQACDHVzZXIgPSBhbGljZQAABiBL6WfNHqDGsmuvakqU7psFsViG2guoXoxCqTyNDhJe_A",
+            .num_caveats = num_caveats,
+            .caveats = c
+    };
+    verify_macaroon(&t);
+}
+
 TEST_GROUP_RUNNER(VerifierTests) {
     RUN_TEST_CASE(VerifierTests, root_v1_1);
     RUN_TEST_CASE(VerifierTests, root_v1_2);
@@ -113,4 +320,15 @@ TEST_GROUP_RUNNER(VerifierTests) {
 
     RUN_TEST_CASE(VerifierTests, caveat_v1_1);
     RUN_TEST_CASE(VerifierTests, caveat_v1_2);
+    RUN_TEST_CASE(VerifierTests, caveat_v1_3);
+    RUN_TEST_CASE(VerifierTests, caveat_v1_4);
+    RUN_TEST_CASE(VerifierTests, caveat_v1_5);
+    RUN_TEST_CASE(VerifierTests, caveat_v1_6);
+
+    RUN_TEST_CASE(VerifierTests, caveat_v2_1);
+    RUN_TEST_CASE(VerifierTests, caveat_v2_2);
+    RUN_TEST_CASE(VerifierTests, caveat_v2_3);
+    RUN_TEST_CASE(VerifierTests, caveat_v2_4);
+    RUN_TEST_CASE(VerifierTests, caveat_v2_5);
+    RUN_TEST_CASE(VerifierTests, caveat_v2_6);
 }

--- a/test/unity/verifier_tests.c
+++ b/test/unity/verifier_tests.c
@@ -1,0 +1,116 @@
+//
+// Created by Nick Robison on 2/18/21.
+//
+/* C */
+#include <stdbool.h>
+
+/* unity */
+#include "unity_fixture.h"
+
+struct verifier_test {
+    int version;
+    bool authorized;
+    char *serialized;
+    unsigned char *key;
+    size_t num_caveats;
+    char **caveats;
+};
+
+void verify_macaroon(const struct verifier_test* test);
+
+
+TEST_GROUP(VerifierTests);
+
+TEST_SETUP(VerifierTests) {
+
+}
+
+TEST_TEAR_DOWN(VerifierTests) {
+
+}
+
+TEST(VerifierTests, root_v1_1) {
+    struct verifier_test t = {
+            .version = 1,
+            .authorized = true,
+            .key = "this is the key",
+            .serialized = "TURBeU1XeHZZMkYwYVc5dUlHaDBkSEE2THk5bGVHRnRjR3hsTG05eVp5OEtNREF4Tldsa1pXNTBhV1pwWlhJZ2EyVjVhV1FLTURBeVpuTnBaMjVoZEhWeVpTQjgzdWVTVVJ4Ynh2VW9TRmdGMy1teVRuaGVLT0twa3dINTF4SEdDZU9POXdv"
+    };
+    verify_macaroon(&t);
+}
+
+TEST(VerifierTests, root_v1_2) {
+    struct verifier_test t = {
+            .version = 1,
+            .authorized = false,
+            .key = "this is not the key",
+            .serialized = "TURBeU1XeHZZMkYwYVc5dUlHaDBkSEE2THk5bGVHRnRjR3hsTG05eVp5OEtNREF4Tldsa1pXNTBhV1pwWlhJZ2EyVjVhV1FLTURBeVpuTnBaMjVoZEhWeVpTQjgzdWVTVVJ4Ynh2VW9TRmdGMy1teVRuaGVLT0twa3dINTF4SEdDZU9POXdv"
+    };
+    verify_macaroon(&t);
+}
+
+TEST(VerifierTests, root_v2_1) {
+    struct verifier_test t = {
+            .version = 1,
+            .authorized = true,
+            .key = "this is the key",
+            .serialized = "AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAAYgfN7nklEcW8b1KEhYBd_psk54XijiqZMB-dcRxgnjjvc"
+    };
+    verify_macaroon(&t);
+}
+
+TEST(VerifierTests, root_v2_2) {
+    struct verifier_test t = {
+            .version = 1,
+            .authorized = false,
+            .key = "this is not the key",
+            .serialized = "AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAAYgfN7nklEcW8b1KEhYBd_psk54XijiqZMB-dcRxgnjjvc"
+    };
+    verify_macaroon(&t);
+}
+
+TEST(VerifierTests, caveat_v1_1) {
+    char *caveats[1] = {"account = 3735928559"};
+
+    char **c = (char**)(malloc(1 * sizeof(char*)));
+
+    c[0] = caveats[0];
+
+    struct verifier_test t = {
+            .version = 1,
+            .authorized = true,
+            .key = "this is the key",
+            .serialized = "TURBeU1XeHZZMkYwYVc5dUlHaDBkSEE2THk5bGVHRnRjR3hsTG05eVp5OEtNREF4Tldsa1pXNTBhV1pwWlhJZ2EyVjVhV1FLTURBeVpuTnBaMjVoZEhWeVpTQjgzdWVTVVJ4Ynh2VW9TRmdGMy1teVRuaGVLT0twa3dINTF4SEdDZU9POXdv",
+            .num_caveats = 1,
+            .caveats = c
+    };
+    verify_macaroon(&t);
+}
+
+TEST(VerifierTests, caveat_v1_2) {
+    char *caveats[1] = {"account = 0000000000"};
+
+    char **c = (char**)(malloc(1 * sizeof(char*)));
+
+    c[0] = caveats[0];
+
+    struct verifier_test t = {
+            .version = 1,
+            .authorized = false,
+            .key = "this is the key",
+            .serialized = "TURBeU1XeHZZMkYwYVc5dUlHaDBkSEE2THk5bGVHRnRjR3hsTG05eVp5OEtNREF4Tldsa1pXNTBhV1pwWlhJZ2EyVjVhV1FLTURBeFpHTnBaQ0JoWTJOdmRXNTBJRDBnTXpjek5Ua3lPRFUxT1Fvd01ESm1jMmxuYm1GMGRYSmxJUFZJQl9iY2J0LUl2dzl6QnJPQ0pXS2pZbE05djNNNXVtRjJYYVM5SloySENn",
+            .num_caveats = 1,
+            .caveats = c
+    };
+    verify_macaroon(&t);
+}
+
+TEST_GROUP_RUNNER(VerifierTests) {
+    RUN_TEST_CASE(VerifierTests, root_v1_1);
+    RUN_TEST_CASE(VerifierTests, root_v1_2);
+    RUN_TEST_CASE(VerifierTests, root_v2_1);
+    RUN_TEST_CASE(VerifierTests, root_v2_2);
+
+    RUN_TEST_CASE(VerifierTests, caveat_v1_1);
+    RUN_TEST_CASE(VerifierTests, caveat_v1_2);
+}

--- a/test/unity/verifier_tests.c
+++ b/test/unity/verifier_tests.c
@@ -124,7 +124,7 @@ TEST(VerifierTests, caveat_v1_3) {
 }
 
 TEST(VerifierTests, caveat_v1_4) {
-    const size_t num_caveats = 2;
+    static const size_t num_caveats = 2;
     const char *caveats[num_caveats] = {
             "account = 3735928559",
             "user = alice"
@@ -147,7 +147,7 @@ TEST(VerifierTests, caveat_v1_4) {
 }
 
 TEST(VerifierTests, caveat_v1_5) {
-    const size_t num_caveats = 1;
+    static const size_t num_caveats = 1;
     const char *caveats[num_caveats] = {
             "account = 3735928559",
     };
@@ -169,7 +169,7 @@ TEST(VerifierTests, caveat_v1_5) {
 }
 
 TEST(VerifierTests, caveat_v1_6) {
-    const size_t num_caveats = 1;
+    static const size_t num_caveats = 1;
     const char *caveats[num_caveats] = {
             "user = alice",
     };
@@ -191,7 +191,7 @@ TEST(VerifierTests, caveat_v1_6) {
 }
 
 TEST(VerifierTests, caveat_v2_1) {
-    const size_t num_caveats = 1;
+    static const size_t num_caveats = 1;
     const char *caveats[num_caveats] = {
             "account = 3735928559",
     };
@@ -213,7 +213,7 @@ TEST(VerifierTests, caveat_v2_1) {
 }
 
 TEST(VerifierTests, caveat_v2_2) {
-    const size_t num_caveats = 1;
+    static const size_t num_caveats = 1;
     const char *caveats[num_caveats] = {
             "account = 0000000000",
     };
@@ -246,7 +246,7 @@ TEST(VerifierTests, caveat_v2_3) {
 }
 
 TEST(VerifierTests, caveat_v2_4) {
-    const size_t num_caveats = 2;
+    static const size_t num_caveats = 2;
     const char *caveats[num_caveats] = {
             "account = 3735928559",
             "user = alice",
@@ -269,7 +269,7 @@ TEST(VerifierTests, caveat_v2_4) {
 }
 
 TEST(VerifierTests, caveat_v2_5) {
-    const size_t num_caveats = 1;
+    static const size_t num_caveats = 1;
     const char *caveats[num_caveats] = {
             "account = 3735928559",
     };
@@ -291,7 +291,7 @@ TEST(VerifierTests, caveat_v2_5) {
 }
 
 TEST(VerifierTests, caveat_v2_6) {
-    const size_t num_caveats = 1;
+    static const size_t num_caveats = 1;
     const char *caveats[num_caveats] = {
             "user = alice",
     };


### PR DESCRIPTION
We're now running the entire macaroon test suite via the Unity test framework.

We still need to run the README doctests, but that will require figuring out how to build the python bindings with CMake.