### PR TITLE
Add methods for getting the number of macaroon caveats

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build and Test
-on: [push]
+on: [pull_request]
 
 jobs:
   job:

--- a/macaroons.c
+++ b/macaroons.c
@@ -468,6 +468,31 @@ macaroon_bind(const unsigned char* Msig,
 }
 
 MACAROON_API unsigned
+macaroon_num_caveats(const struct macaroon* M)
+{
+    VALIDATE(M);
+    return M->num_caveats;
+}
+
+MACAROON_API unsigned
+macaroon_num_first_party_caveats(const struct macaroon* M)
+{
+    size_t idx = 0;
+    unsigned count = 0;
+    VALIDATE(M);
+
+    for (idx = 0; idx < M->num_caveats; ++idx)
+    {
+        if (M->caveats[idx].vid.size == 0 && M->caveats[idx].cl.size == 0)
+        {
+            ++count;
+        }
+    }
+
+    return count;
+}
+
+MACAROON_API unsigned
 macaroon_num_third_party_caveats(const struct macaroon* M)
 {
     size_t idx = 0;

--- a/macaroons.h
+++ b/macaroons.h
@@ -94,6 +94,12 @@ macaroon_destroy(struct macaroon* M);
 int
 macaroon_validate(const struct macaroon* M);
 
+/* Return the number of caveats for the given macaroon.
+ * This includes both first-party and third-party caveats
+ */
+unsigned
+macaroon_num_caveats(const struct macaroon* M);
+
 /* Add a new first party caveat, and return a new macaroon.
  *  - predicate/predicate_sz is the caveat to be added to the macaroon
  *
@@ -103,6 +109,12 @@ struct macaroon*
 macaroon_add_first_party_caveat(const struct macaroon* M,
                                 const unsigned char* predicate, size_t predicate_sz,
                                 enum macaroon_returncode* err);
+
+/* Return the number of first-party caveats for the given macaroon
+ *
+ */
+unsigned
+macaroon_num_first_party_caveats(const struct macaroon* M);
 
 /* Add a new third party caveat, and return a new macaroon.
  *  - location/location_sz is a hint to the third party's location

--- a/test/unity/test_helpers.c
+++ b/test/unity/test_helpers.c
@@ -58,10 +58,10 @@ void verify_macaroon(const struct verifier_test *test) {
     TEST_ASSERT_NOT_NULL_MESSAGE(V, "Verifier should create ok");
 
     // Add all the caveats
-    for(size_t i = 0; i < test->num_caveats; i++) {
-        char* caveat = test->caveats[i];
+    for (size_t i = 0; i < test->num_caveats; i++) {
+        char *caveat = test->caveats[i];
         enum macaroon_returncode err = MACAROON_SUCCESS;
-        macaroon_verifier_satisfy_exact(V, (const unsigned char*)caveat, strlen(caveat), &err);
+        macaroon_verifier_satisfy_exact(V, (const unsigned char *) caveat, strlen(caveat), &err);
         TEST_ASSERT_EQUAL_INT_MESSAGE(MACAROON_SUCCESS, err, "Should have added caveat");
     }
 
@@ -80,8 +80,18 @@ void verify_macaroon(const struct verifier_test *test) {
     macaroons = tmp;
     (macaroons)[macaroons_sz - 1] = M;
 
+    // Look at the first macaroon and make sure it has the correct number of caveats
+    if (test->authorized) {
+        TEST_ASSERT_EQUAL_size_t_MESSAGE(test->num_caveats, macaroon_num_caveats(macaroons[0]),
+                                         "Should have the correct number of caveats");
+        TEST_ASSERT_EQUAL_size_t_MESSAGE(test->num_caveats, macaroon_num_first_party_caveats(macaroons[0]),
+                                         "All caveats should be first-party");
+        TEST_ASSERT_EQUAL_size_t_MESSAGE(0, macaroon_num_third_party_caveats(macaroons[0]),
+                                         "Should not have any third-party caveats");
+    }
+
     // Ok, now let's verify it
-    const size_t key_sz = strlen((const char*)test->key);
+    const size_t key_sz = strlen((const char *) test->key);
     enum macaroon_returncode err;
     int verify = macaroon_verify(V, macaroons[0], test->key, key_sz, macaroons + 1, macaroons_sz - 1, &err);
 

--- a/test/unity/verifier_tests.c
+++ b/test/unity/verifier_tests.c
@@ -80,7 +80,7 @@ TEST(VerifierTests, caveat_v1_1) {
             .version = 1,
             .authorized = true,
             .key = "this is the key",
-            .serialized = "TURBeU1XeHZZMkYwYVc5dUlHaDBkSEE2THk5bGVHRnRjR3hsTG05eVp5OEtNREF4Tldsa1pXNTBhV1pwWlhJZ2EyVjVhV1FLTURBeVpuTnBaMjVoZEhWeVpTQjgzdWVTVVJ4Ynh2VW9TRmdGMy1teVRuaGVLT0twa3dINTF4SEdDZU9POXdv",
+            .serialized = "TURBeU1XeHZZMkYwYVc5dUlHaDBkSEE2THk5bGVHRnRjR3hsTG05eVp5OEtNREF4Tldsa1pXNTBhV1pwWlhJZ2EyVjVhV1FLTURBeFpHTnBaQ0JoWTJOdmRXNTBJRDBnTXpjek5Ua3lPRFUxT1Fvd01ESm1jMmxuYm1GMGRYSmxJUFZJQl9iY2J0LUl2dzl6QnJPQ0pXS2pZbE05djNNNXVtRjJYYVM5SloySENn",
             .num_caveats = 1,
             .caveats = c
     };
@@ -139,7 +139,7 @@ TEST(VerifierTests, caveat_v1_4) {
             .version = 1,
             .authorized = true,
             .key = "this is the key",
-            .serialized = "TURBeU1XeHZZMkYwYVc5dUlHaDBkSEE2THk5bGVHRnRjR3hsTG05eVp5OEtNREF4Tldsa1pXNTBhV1pwWlhJZ2EyVjVhV1FLTURBeFpHTnBaQ0JoWTJOdmRXNTBJRDBnTXpjek5Ua3lPRFUxT1Fvd01ESm1jMmxuYm1GMGRYSmxJUFZJQl9iY2J0LUl2dzl6QnJPQ0pXS2pZbE05djNNNXVtRjJYYVM5SloySENn",
+            .serialized = "TURBeU1XeHZZMkYwYVc5dUlHaDBkSEE2THk5bGVHRnRjR3hsTG05eVp5OEtNREF4Tldsa1pXNTBhV1pwWlhJZ2EyVjVhV1FLTURBeFpHTnBaQ0JoWTJOdmRXNTBJRDBnTXpjek5Ua3lPRFUxT1Fvd01ERTFZMmxrSUhWelpYSWdQU0JoYkdsalpRb3dNREptYzJsbmJtRjBkWEpsSUV2cFo4MGVvTWF5YTY5cVNwVHVtd1d4V0liYUM2aGVqRUtwUEkwT0VsNzhDZw==",
             .num_caveats = num_caveats,
             .caveats = c
     };


### PR DESCRIPTION
We can now get the total number of caveats, along with the number of first_party, which is in addition to existing third_party numeration methods.

Also update CI to run on PRs instead of just pushes.